### PR TITLE
Fix building on GCC 10

### DIFF
--- a/rle.h
+++ b/rle.h
@@ -30,7 +30,7 @@ extern "C" {
  *** 43+3 codec ***
  ******************/
 
-const uint8_t rle_auxtab[8];
+extern const uint8_t rle_auxtab[8];
 
 #define RLE_MIN_SPACE 18
 #define rle_nptr(block) ((uint16_t*)(block))


### PR DESCRIPTION
GCC 10 defaults to `-fno-common`, so we cannot define this twice without explicitly specifying `extern`.